### PR TITLE
fix: improve pick and omit with UnionKeys

### DIFF
--- a/src/Omit.spec.ts
+++ b/src/Omit.spec.ts
@@ -41,6 +41,21 @@ test('distributive omit', () => {
   actions.push({ ...x, id: '1' })
 })
 
+test('distributive Omit with disjoined keys', () => {
+  type Union = {
+    type: 'A',
+    foo: string
+  } | {
+    type: 'B',
+    foo: string
+    bar: string
+  }
+  type Id<T> = {} & { [P in keyof T]: T[P] }
+  let x: Id<Omit<Union, 'bar'>> = { type: 'A', foo: 'foo' }
+  x = { type: 'B', foo: 'bar' }
+  expect(x.foo).toBe('bar')
+})
+
 test('intersection types with generic', () => {
   type Foo = { a: string, b: string }
   function foo<T>(input: Omit<Foo & T, 'a'>): void {

--- a/src/Omit.ts
+++ b/src/Omit.ts
@@ -1,4 +1,6 @@
+import { UnionKeys } from './UnionKeys';
+
 // by Titian Cernicova-Dragomir
 // https://github.com/microsoft/TypeScript/issues/28339#issuecomment-463577347
 // type-zoo
-export type Omit<T, K extends keyof T> = T extends T ? Pick<T, Exclude<keyof T, K>> : never;
+export type Omit<T, K extends UnionKeys<T>> = T extends T ? Pick<T, Exclude<keyof T, K>> : never;

--- a/src/UnionKeys.ts
+++ b/src/UnionKeys.ts
@@ -1,0 +1,5 @@
+/**
+ * `UnionKeys<T>` will distribute keys of an union to individual types.
+ * This should be used in conjuncture with distributive types.
+ */
+export type UnionKeys<T> = keyof T | (T extends T ? keyof T : never)

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,4 +26,5 @@ export * from './reduceKey';
 export * from './Required';
 export * from './tryAssign';
 export * from './typeAssert';
+export * from './UnionKeys';
 export * from './ValueOf';

--- a/src/pick.spec.ts
+++ b/src/pick.spec.ts
@@ -28,6 +28,22 @@ test('distributive pick', () => {
   actions.push({ ...x, id: '1' })
 })
 
+test('distributive pick with disjoined keys', () => {
+  type Union = {
+    type: 'A',
+    foo: string
+  } | {
+    type: 'B',
+    foo: string
+    bar: string
+  }
+  type Id<T> = {} & { [P in keyof T]: T[P] }
+  let x: Id<Pick<Union, 'type' | 'bar'>> = { type: 'A' }
+  x = { type: 'B', bar: 'bar' }
+
+  expect(x.bar).toBe('bar')
+})
+
 test('intersection types with generic', () => {
   type Foo = { a: string, b: string }
   function foo<T>(input: Pick<Foo & T, 'a'>): void {
@@ -35,3 +51,4 @@ test('intersection types with generic', () => {
   }
   foo({ a: '1' })
 })
+

--- a/src/pick.ts
+++ b/src/pick.ts
@@ -1,25 +1,25 @@
 import { reduceKey } from './reduceKey';
+import { UnionKeys } from './UnionKeys';
 
-export function pick<T extends object, P1 extends keyof T>(subject: T, prop1: P1): Pick<T, P1>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T>(subject: T, prop1: P1, prop2: P2): Pick<T, P1 | P2>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T, P3 extends keyof T>(subject: T, prop1: P1, prop2: P2, prop3: P3): Pick<T, P1 | P2 | P3>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T, P3 extends keyof T, P4 extends keyof T>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4): Pick<T, P1 | P2 | P3 | P4>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T, P3 extends keyof T, P4 extends keyof T, P5 extends keyof T>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5): Pick<T, P1 | P2 | P3 | P4 | P5>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T, P3 extends keyof T, P4 extends keyof T, P5 extends keyof T, P6 extends keyof T>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6): Pick<T, P1 | P2 | P3 | P4 | P5 | P6>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T, P3 extends keyof T, P4 extends keyof T, P5 extends keyof T, P6 extends keyof T, P7 extends keyof T>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T, P3 extends keyof T, P4 extends keyof T, P5 extends keyof T, P6 extends keyof T, P7 extends keyof T, P8 extends keyof T>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7, prop8: P8): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T, P3 extends keyof T, P4 extends keyof T, P5 extends keyof T, P6 extends keyof T, P7 extends keyof T, P8 extends keyof T, P9 extends keyof T>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7, prop8: P8, prop9: P9): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8 | P9>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T, P3 extends keyof T, P4 extends keyof T, P5 extends keyof T, P6 extends keyof T, P7 extends keyof T, P8 extends keyof T, P9 extends keyof T, P10 extends keyof T>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7, prop8: P8, prop9: P9, prop10: P10): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8 | P9 | P10>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T, P3 extends keyof T, P4 extends keyof T, P5 extends keyof T, P6 extends keyof T, P7 extends keyof T, P8 extends keyof T, P9 extends keyof T, P10 extends keyof T, P11 extends keyof T>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7, prop8: P8, prop9: P9, prop10: P10, prop11: P11): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8 | P9 | P10 | P11>
-export function pick<T extends object, P1 extends keyof T, P2 extends keyof T, P3 extends keyof T, P4 extends keyof T, P5 extends keyof T, P6 extends keyof T, P7 extends keyof T, P8 extends keyof T, P9 extends keyof T, P10 extends keyof T, P11 extends keyof T, P12 extends keyof T>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7, prop8: P8, prop9: P9, prop10: P10, prop11: P11, prop12: P12): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8 | P9 | P10 | P11 | P12>
-export function pick<T extends object>(subject: T, ...props: Array<keyof T>) {
+export function pick<T extends object, P1 extends UnionKeys<T>>(subject: T, prop1: P1): Pick<T, P1>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2): Pick<T, P1 | P2>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>, P3 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2, prop3: P3): Pick<T, P1 | P2 | P3>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>, P3 extends UnionKeys<T>, P4 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4): Pick<T, P1 | P2 | P3 | P4>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>, P3 extends UnionKeys<T>, P4 extends UnionKeys<T>, P5 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5): Pick<T, P1 | P2 | P3 | P4 | P5>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>, P3 extends UnionKeys<T>, P4 extends UnionKeys<T>, P5 extends UnionKeys<T>, P6 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6): Pick<T, P1 | P2 | P3 | P4 | P5 | P6>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>, P3 extends UnionKeys<T>, P4 extends UnionKeys<T>, P5 extends UnionKeys<T>, P6 extends UnionKeys<T>, P7 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>, P3 extends UnionKeys<T>, P4 extends UnionKeys<T>, P5 extends UnionKeys<T>, P6 extends UnionKeys<T>, P7 extends UnionKeys<T>, P8 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7, prop8: P8): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>, P3 extends UnionKeys<T>, P4 extends UnionKeys<T>, P5 extends UnionKeys<T>, P6 extends UnionKeys<T>, P7 extends UnionKeys<T>, P8 extends UnionKeys<T>, P9 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7, prop8: P8, prop9: P9): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8 | P9>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>, P3 extends UnionKeys<T>, P4 extends UnionKeys<T>, P5 extends UnionKeys<T>, P6 extends UnionKeys<T>, P7 extends UnionKeys<T>, P8 extends UnionKeys<T>, P9 extends UnionKeys<T>, P10 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7, prop8: P8, prop9: P9, prop10: P10): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8 | P9 | P10>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>, P3 extends UnionKeys<T>, P4 extends UnionKeys<T>, P5 extends UnionKeys<T>, P6 extends UnionKeys<T>, P7 extends UnionKeys<T>, P8 extends UnionKeys<T>, P9 extends UnionKeys<T>, P10 extends UnionKeys<T>, P11 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7, prop8: P8, prop9: P9, prop10: P10, prop11: P11): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8 | P9 | P10 | P11>
+export function pick<T extends object, P1 extends UnionKeys<T>, P2 extends UnionKeys<T>, P3 extends UnionKeys<T>, P4 extends UnionKeys<T>, P5 extends UnionKeys<T>, P6 extends UnionKeys<T>, P7 extends UnionKeys<T>, P8 extends UnionKeys<T>, P9 extends UnionKeys<T>, P10 extends UnionKeys<T>, P11 extends UnionKeys<T>, P12 extends UnionKeys<T>>(subject: T, prop1: P1, prop2: P2, prop3: P3, prop4: P4, prop5: P5, prop6: P6, prop7: P7, prop8: P8, prop9: P9, prop10: P10, prop11: P11, prop12: P12): Pick<T, P1 | P2 | P3 | P4 | P5 | P6 | P7 | P8 | P9 | P10 | P11 | P12>
+export function pick<T extends object>(subject: T, ...props: Array<UnionKeys<T>>) {
   return reduceKey(subject, (p, k) => {
     if (props.indexOf(k) >= 0) p[k] = subject[k]
     return p
   }, {} as any)
 }
 
-
 // by Titian Cernicova-Dragomir
 // https://github.com/microsoft/TypeScript/issues/28339#issuecomment-463577347
-export type Pick<T, K extends keyof T> = T extends T ? { [P in K]: T[P] } : never
+export type Pick<T, K extends UnionKeys<T>> = T extends T ? { [P in Extract<K, keyof T>]: T[P] } : never


### PR DESCRIPTION
Using `UnionKeys` allows to pick from all keys from the keys of every entry in the union.

And it will distribute the keys to the respective type with the help of `Extract<K, keyof T>`

Thanks you @dragomirtitian for the detailed discussion in #31 