### PR TITLE
fix: rename isType.true|false to t|f

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,27 +229,27 @@ You need to specify `T`.
 
 `isType<T>(subject, Class)`:
 
-`isType.true<T>(subject?: T)`:
+`isType.t<T>(subject?: T)`:
 
 ✔️ `immediate`, `runtime`
 
-It can used as type check: `isType.true<Equal<A, B>>()`,
-or value type check: `isType.true(valueTypeIsTrue)`.
+It can used as type check: `isType.t<Equal<A, B>>()`,
+or value type check: `isType.t(valueTypeIsTrue)`.
 It returns `true` when passes (which is the only case when used in TypeScript).
 
-`isType.false<T>(subject?: T)`:
+`isType.f<T>(subject?: T)`:
 
 ✔️ `immediate`, `runtime`
 
-It can used as type check: `isType.false<Equal<A, B>>()`,
-or value type check: `isType.false(valueTypeIsFalse)`.
+It can used as type check: `isType.f<Equal<A, B>>()`,
+or value type check: `isType.f(valueTypeIsFalse)`.
 It returns `true` when passes (which is the only case when used in TypeScript).
 
 `isType.equal<true|false, A, B>()`:
 
 ✔️ `immediate`
 
-Slightly easier to use then `isType.true<>()` and `isType.false<>()`,
+Slightly easier to use then `isType.t<>()` and `isType.f<>()`,
 when doing type level only equality comparison as you don't have to import `Equal<>`.
 
 ✔️ `type guard`, `runtime`

--- a/src/array/Concat.spec.ts
+++ b/src/array/Concat.spec.ts
@@ -2,20 +2,20 @@ import { Concat, Equal, isType } from '..'
 
 test('concat array', () => {
   type A = Concat<string[], boolean[]>
-  isType.true<Equal<Array<string | boolean>, A>>()
+  isType.t<Equal<Array<string | boolean>, A>>()
 })
 
 test('concat tuples', () => {
   type A = Concat<[1, 2, 3], [4, 5]>
-  isType.true<Equal<[1, 2, 3, 4, 5], A>>()
+  isType.t<Equal<[1, 2, 3, 4, 5], A>>()
 })
 
 test('concat array to tuple', () => {
   type A = Concat<string[], [1, 2, 3]>
-  isType.true<Equal<Array<string | 1 | 2 | 3>, A>>()
+  isType.t<Equal<Array<string | 1 | 2 | 3>, A>>()
 })
 
 test('concat tuple to array', () => {
   type A = Concat<[1, 2, 3], string[]>
-  isType.true<Equal<[1, 2, 3, ...string[]], A>>()
+  isType.t<Equal<[1, 2, 3, ...string[]], A>>()
 })

--- a/src/functional/Maybe.spec.ts
+++ b/src/functional/Maybe.spec.ts
@@ -37,4 +37,7 @@ test('Just<number can assign to Maybe<number>', () => {
 
 test('Just<string> is not assignable to Maybe<number>', () => {
   assertType.isFalse(false as CanAssign<Just<'abc'>, Maybe<number>>)
+
+  // this is failing, which is wrong
+  // assertType.isFalse(canAssign<Maybe<number>>()(just('abc')))
 })

--- a/src/functional/Maybe.ts
+++ b/src/functional/Maybe.ts
@@ -1,15 +1,15 @@
 import { Brand } from '../nominal-types'
-import { Equal, If } from '../predicates'
+import { Equal } from '../predicates'
 import { Widen } from '../utils'
 
 export type Maybe<T> = Just<T> | None<T>
 export type Just<T> = Brand<'maybe', T> & { unwrap(): T }
 export type None<T> = Brand<'maybe', void> & { unwrap(): T }
 
-export function just<T>(value: T): If<
-  Equal<T, undefined | null>,
-  None<T>,
-  Just<Widen<NonNullable<T>>>> {
+export function just<T>(value: T):
+  Equal<T, undefined | null> extends true ?
+  None<T> :
+  Just<Widen<NonNullable<T>>> {
   return { unwrap() { return value } } as any
 }
 

--- a/src/math/Digit.spec.ts
+++ b/src/math/Digit.spec.ts
@@ -4,34 +4,34 @@ import { Digit, DigitArray } from './Digit'
 describe('DigitArray.ToNumber<DA>', () => {
   test('no digit gets 0', () => {
     type A = DigitArray.ToNumber<[]>
-    isType.true<Equal<A, 0>>()
+    isType.t<Equal<A, 0>>()
   })
 
   test('single digit', () => {
-    isType.true<Equal<DigitArray.ToNumber<[0]>, 0>>()
-    isType.true<Equal<DigitArray.ToNumber<[1]>, 1>>()
-    isType.true<Equal<DigitArray.ToNumber<[2]>, 2>>()
-    isType.true<Equal<DigitArray.ToNumber<[3]>, 3>>()
-    isType.true<Equal<DigitArray.ToNumber<[4]>, 4>>()
-    isType.true<Equal<DigitArray.ToNumber<[5]>, 5>>()
-    isType.true<Equal<DigitArray.ToNumber<[6]>, 6>>()
-    isType.true<Equal<DigitArray.ToNumber<[7]>, 7>>()
-    isType.true<Equal<DigitArray.ToNumber<[8]>, 8>>()
-    isType.true<Equal<DigitArray.ToNumber<[9]>, 9>>()
+    isType.t<Equal<DigitArray.ToNumber<[0]>, 0>>()
+    isType.t<Equal<DigitArray.ToNumber<[1]>, 1>>()
+    isType.t<Equal<DigitArray.ToNumber<[2]>, 2>>()
+    isType.t<Equal<DigitArray.ToNumber<[3]>, 3>>()
+    isType.t<Equal<DigitArray.ToNumber<[4]>, 4>>()
+    isType.t<Equal<DigitArray.ToNumber<[5]>, 5>>()
+    isType.t<Equal<DigitArray.ToNumber<[6]>, 6>>()
+    isType.t<Equal<DigitArray.ToNumber<[7]>, 7>>()
+    isType.t<Equal<DigitArray.ToNumber<[8]>, 8>>()
+    isType.t<Equal<DigitArray.ToNumber<[9]>, 9>>()
 
   })
 
   test('two digits', () => {
-    isType.true<Equal<DigitArray.ToNumber<[1, 0]>, 10>>()
-    isType.true<Equal<DigitArray.ToNumber<[1, 0]>, 10>>()
-    isType.true<Equal<DigitArray.ToNumber<[3, 1]>, 31>>()
-    isType.true<Equal<DigitArray.ToNumber<[13, 1]>, 131>>()
-    isType.true<Equal<DigitArray.ToNumber<[1, 2, 3, 4]>, 1234>>()
+    isType.t<Equal<DigitArray.ToNumber<[1, 0]>, 10>>()
+    isType.t<Equal<DigitArray.ToNumber<[1, 0]>, 10>>()
+    isType.t<Equal<DigitArray.ToNumber<[3, 1]>, 31>>()
+    isType.t<Equal<DigitArray.ToNumber<[13, 1]>, 131>>()
+    isType.t<Equal<DigitArray.ToNumber<[1, 2, 3, 4]>, 1234>>()
   })
 
   test('multi digits', () => {
-    isType.true<Equal<DigitArray.ToNumber<[1, 2, 3, 4, 5]>, 12345>>()
-    isType.true<Equal<DigitArray.ToNumber<[1, 2, 3, 4, 15]>, 12355>>()
+    isType.t<Equal<DigitArray.ToNumber<[1, 2, 3, 4, 5]>, 12345>>()
+    isType.t<Equal<DigitArray.ToNumber<[1, 2, 3, 4, 15]>, 12355>>()
   })
 })
 

--- a/src/math/GreaterThan.spec.ts
+++ b/src/math/GreaterThan.spec.ts
@@ -17,24 +17,24 @@ test('override Fail case', () => {
 })
 
 test('n > n is false', () => {
-  isType.false<GreaterThan<0, 0>>()
-  isType.false<GreaterThan<1, 1>>()
-  isType.false<GreaterThan<12, 12>>()
+  isType.f<GreaterThan<0, 0>>()
+  isType.f<GreaterThan<1, 1>>()
+  isType.f<GreaterThan<12, 12>>()
 })
 
 test('with same number of digits', () => {
-  isType.true<GreaterThan<1, 0>>()
-  isType.true<GreaterThan<22, 11>>()
-  isType.true<GreaterThan<20, 19>>()
+  isType.t<GreaterThan<1, 0>>()
+  isType.t<GreaterThan<22, 11>>()
+  isType.t<GreaterThan<20, 19>>()
 
-  isType.false<GreaterThan<0, 1>>()
-  isType.false<GreaterThan<11, 22>>()
-  isType.false<GreaterThan<19, 20>>()
+  isType.f<GreaterThan<0, 1>>()
+  isType.f<GreaterThan<11, 22>>()
+  isType.f<GreaterThan<19, 20>>()
 })
 
 test('with different number of digits', () => {
-  isType.false<GreaterThan<0, 1>>()
-  isType.false<GreaterThan<9, 100>>()
-  isType.true<GreaterThan<10, 1>>()
-  isType.true<GreaterThan<123, 32>>()
+  isType.f<GreaterThan<0, 1>>()
+  isType.f<GreaterThan<9, 100>>()
+  isType.t<GreaterThan<10, 1>>()
+  isType.t<GreaterThan<123, 32>>()
 })

--- a/src/math/IsPositive.spec.ts
+++ b/src/math/IsPositive.spec.ts
@@ -1,15 +1,15 @@
 import { IsPositive, isType } from '..'
 
 test('positive is true', () => {
-  isType.true<IsPositive<0>>()
-  isType.true<IsPositive<1>>()
-  isType.true(true)
+  isType.t<IsPositive<0>>()
+  isType.t<IsPositive<1>>()
+  isType.t(true)
 })
 
 test('negative is false', () => {
-  isType.false<IsPositive<-1>>()
+  isType.f<IsPositive<-1>>()
 })
 
 test('number type is false because we cannot determine', () => {
-  isType.false<IsPositive<number>>()
+  isType.f<IsPositive<number>>()
 })

--- a/src/math/IsWhole.spec.ts
+++ b/src/math/IsWhole.spec.ts
@@ -1,19 +1,19 @@
 import { isType, IsWhole } from '..'
 
 test('whole number is true', () => {
-  isType.true<IsWhole<1>>()
-  isType.true<IsWhole<1.>>()
-  isType.true<IsWhole<0>>()
-  isType.true<IsWhole<0.>>()
-  isType.true<IsWhole<-0>>()
-  isType.true<IsWhole<-1>>()
+  isType.t<IsWhole<1>>()
+  isType.t<IsWhole<1.>>()
+  isType.t<IsWhole<0>>()
+  isType.t<IsWhole<0.>>()
+  isType.t<IsWhole<-0>>()
+  isType.t<IsWhole<-1>>()
 })
 
 test('fraction is false', () => {
-  isType.false<IsWhole<0.1>>()
-  isType.false<IsWhole<-0.1>>()
+  isType.f<IsWhole<0.1>>()
+  isType.f<IsWhole<-0.1>>()
 })
 
 test('number type is false because we cannot determine', () => {
-  isType.false<IsWhole<number>>()
+  isType.f<IsWhole<number>>()
 })

--- a/src/nominal-types/Brand.spec.ts
+++ b/src/nominal-types/Brand.spec.ts
@@ -5,13 +5,13 @@ describe('brand()', () => {
   test('unbranded type cannot assign to branded type', () => {
     const a = brand('a', { a: 1 })
     const b = { a: 1 }
-    isType.false<CanAssign<typeof b, typeof a>>()
+    isType.f<CanAssign<typeof b, typeof a>>()
   })
   test('basic use case', () => {
     const a = brand('a', { a: 1 as const })
     const b = brand('b', { b: 'b' })
 
-    isType.false<CanAssign<typeof a, typeof b>>()
+    isType.f<CanAssign<typeof a, typeof b>>()
     assertType<1>(a.a)
     assertType<string>(b.b)
   })
@@ -25,7 +25,7 @@ describe('brand()', () => {
   test('flavor with the same name cannot be assigned to brand', () => {
     const b = brand('x', { a: 1 })
     const f = flavor('x', { a: 1 })
-    isType.false<CanAssign<typeof f, typeof b>>()
+    isType.f<CanAssign<typeof f, typeof b>>()
   })
   test('without subject creates a typed brand creator', () => {
     const createPerson = brand('person')
@@ -38,6 +38,6 @@ describe('brand()', () => {
     person1 = person2
     person2 = person1
 
-    isType.false<Equal<typeof blogPost, typeof person1>>()
+    isType.f<Equal<typeof blogPost, typeof person1>>()
   })
 })

--- a/src/nominal-types/Flavor.spec.ts
+++ b/src/nominal-types/Flavor.spec.ts
@@ -12,7 +12,7 @@ test('underlying type can be assigned to Flavor', () => {
 
   const blogId: BlogId = 1
 
-  isType.false<CanAssign<typeof blogId, typeof personId>>()
+  isType.f<CanAssign<typeof blogId, typeof personId>>()
 })
 
 describe('flavor()', () => {
@@ -20,7 +20,7 @@ describe('flavor()', () => {
     const a = flavor('a', { a: 1 as const })
     const b = flavor('b', { b: 'b' })
 
-    isType.false<CanAssign<typeof a, typeof b>>()
+    isType.f<CanAssign<typeof a, typeof b>>()
     assertType<1>(a.a)
     assertType<string>(b.b)
   })
@@ -33,7 +33,7 @@ describe('flavor()', () => {
   test('brand with the same name can be assigned to flavor', () => {
     const b = brand('x', { a: 1 })
     const f = flavor('x', { a: 1 })
-    isType.true<CanAssign<typeof b, typeof f>>()
+    isType.t<CanAssign<typeof b, typeof f>>()
   })
   test('without subject creates a typed flavor creator', () => {
     const createPerson = flavor('person')
@@ -46,6 +46,6 @@ describe('flavor()', () => {
     person1 = person2
     person2 = person1
 
-    isType.false<CanAssign<typeof blogPost, typeof person1>>()
+    isType.f<CanAssign<typeof blogPost, typeof person1>>()
   })
 })

--- a/src/object/IsDisjoint.spec.ts
+++ b/src/object/IsDisjoint.spec.ts
@@ -3,23 +3,23 @@ import { isType, IsDisjoint } from '..'
 test('disjoint returns true', () => {
   type A = { a: 1 }
   type B = { b: 1 }
-  isType.true<IsDisjoint<A, B>>()
+  isType.t<IsDisjoint<A, B>>()
 })
 
 test('same type returns false', () => {
   type A = { a: 1 }
   type B = { a: 1 }
-  isType.false<IsDisjoint<A, B>>()
+  isType.f<IsDisjoint<A, B>>()
 })
 
 test('A subset of B returns false', () => {
   type A = { a: 1 }
   type B = { a: 1, b: 1 }
-  isType.false<IsDisjoint<A, B>>()
+  isType.f<IsDisjoint<A, B>>()
 })
 
 test('B subset of A returns false', () => {
   type A = { a: 1, b: 1 }
   type B = { a: 1 }
-  isType.false<IsDisjoint<A, B>>()
+  isType.f<IsDisjoint<A, B>>()
 })

--- a/src/predicates/CanAssign.ts
+++ b/src/predicates/CanAssign.ts
@@ -1,19 +1,18 @@
-import { Equal } from './Equal'
 import { NotExtendable } from './Extends'
 
 /**
  * Can `A` assign to `B`
  */
 export type CanAssign<A, B, Then = true, Else = false> =
-  Equal<A, boolean> extends true ?
-  Equal<B, boolean> extends true ? Then : Else :
+  boolean extends A ?
+  boolean extends B ? Then : Else :
   A extends B ? Then : Else
 
 
 export type IsAssign<A, B, Then = true, Else = false> = CanAssign<A, B, Then, Else>
 
 export function canAssign<T>(canAssign: false): <S>(subject: NotExtendable<S, T>) => true
-export function canAssign<T>(): <S extends T>(subject: S) => true
+export function canAssign<T>(): <S extends T>(subject: S) => CanAssign<S, T>
 export function canAssign<T>(): <S extends T>(subject: S) => any {
   return () => true
 }

--- a/src/predicates/If.spec.ts
+++ b/src/predicates/If.spec.ts
@@ -9,6 +9,6 @@ test('false gets Else', () => {
 })
 
 test('Then defaults to true and Else defaults to false', () => {
-  isType.true<If<true>>()
-  isType.false<If<false>>()
+  isType.t<If<true>>()
+  isType.f<If<false>>()
 })

--- a/src/predicates/isType.spec.ts
+++ b/src/predicates/isType.spec.ts
@@ -60,39 +60,39 @@ describe('isType()', () => {
   })
 })
 
-describe('isType.true()', () => {
+describe('isType.t()', () => {
   test('accept true type but not false or boolean', () => {
-    expect(isType.true<true>()).toBe(true)
-    expect(isType.true<Equal<1, 1>>()).toBe(true)
+    expect(isType.t<true>()).toBe(true)
+    expect(isType.t<Equal<1, 1>>()).toBe(true)
 
     // these fails
-    // isType.true<false>()
-    // isType.true<boolean>()
+    // isType.t<false>()
+    // isType.t<boolean>()
   })
   test('accept value with type true but not false or boolean', () => {
-    expect(isType.true(true)).toBe(true)
+    expect(isType.t(true)).toBe(true)
 
     // these fails
-    // isType.true(false)
-    // isType.true(1 === 1)
+    // isType.t(false)
+    // isType.t(1 === 1)
   })
 })
 
-describe('isType.false()', () => {
+describe('isType.f()', () => {
   test('accept false type but not true or boolean', () => {
-    expect(isType.false<false>()).toBe(true)
-    expect(isType.false<Equal<1, 2>>()).toBe(true)
+    expect(isType.f<false>()).toBe(true)
+    expect(isType.f<Equal<1, 2>>()).toBe(true)
 
     // these fails
-    // isType.false<true>()
-    // isType.false<boolean>()
+    // isType.f<true>()
+    // isType.f<boolean>()
   })
   test('accept value with type true but not false or boolean', () => {
-    expect(isType.false(false)).toBe(true)
+    expect(isType.f(false)).toBe(true)
 
     // these fails
-    // isType.false(true)
-    // isType.false(1 !== 1)
+    // isType.f(true)
+    // isType.f(1 !== 1)
   })
 })
 

--- a/src/predicates/isType.ts
+++ b/src/predicates/isType.ts
@@ -16,16 +16,16 @@ export function isType(subject: any, validator?: any) {
 
 const sym = Symbol()
 
-isType.true = function <T extends true>(subject: T = sym as any) {
+isType.t = function <T extends true>(subject: T = sym as any) {
   return (subject as any) === sym || subject === true
 }
-isType.false = function <T extends false>(subject: T = sym as any) {
+isType.f = function <T extends false>(subject: T = sym as any) {
   return (subject as any) === sym || subject === false
 }
 
 /**
  * are types A and B equals/not equals.
- * Slightly easier to use then `isType.true<>()` and `isType.false<>()`,
+ * Slightly easier to use then `isType.t<>()` and `isType.f<>()`,
  * when doing type level only equality comparison as you don't have to import `Equal<>`.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
The compiled d.ts has syntax error if we named the function true|false.

This is a braking change, but release as a fix.
As the original code doesn't work at all in JavaScript