### PR TITLE
json

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,9 +424,24 @@ type No = IsAny<1, 'yes', 'no'> // 'no'
 
 ### Constant Types
 
-- `JSONTypes`: all JSON compatible types.
 - `KeyTypes`: type of all keys.
 - `PrimitiveTypes`: all primitive types, including `Function`, `symbol`, and `bigint`.
+
+### JSON Support
+
+- `JSONPrimitive`: primitive types valid in JSON
+- `JSONObject`: JSON object
+- `JSONArray`: JSON array
+- `JSONTypes`: all JSON compatible types.
+- `JSONTypes.get<T>(obj, ...props)`: get a cast value in json
+
+```ts
+import { JSONTypes } from 'type-plus'
+
+const someJson: JSONTypes = { a: { b: ['z', { c: 'miku' }]}}
+
+JSONTypes.get<string>(someJson, 'a', 'b', 1, 'c') // miku
+```
 
 ### Object Key functions
 

--- a/package.json
+++ b/package.json
@@ -87,9 +87,6 @@
     "ts-toolbelt": "^8.0.7",
     "typescript": "^4.1.3"
   },
-  "peerDependencies": {
-    "typescript": ">=4.1"
-  },
   "size-limit": [
     {
       "limit": "10 kb"

--- a/src/JSONTypes.spec.ts
+++ b/src/JSONTypes.spec.ts
@@ -1,5 +1,6 @@
 import { assertType } from './assertion'
-import { JSONTypes } from './JSONTypes'
+import { JSONObject, JSONTypes } from './JSONTypes'
+import { isType } from './predicates'
 
 test('empty object', () => {
   assertType<JSONTypes>({})
@@ -11,4 +12,32 @@ test('empty array', () => {
 
 test('string array', () => {
   assertType<JSONTypes>(['a'])
+})
+
+test('JSONObject', () => {
+  isType<JSONObject>({})
+})
+
+describe('JSONTypes.get', () => {
+  test('cast to T | undefined without props', () => {
+    const a = JSONTypes.get<string>('abc')
+    isType<string | undefined>(a)
+    expect(a).toBe('abc')
+  })
+  test('get object props', () => {
+    const a = JSONTypes.get<string>({ a: { b: 'abc' } }, 'a', 'b')
+    isType<string | undefined>(a)
+    expect(a).toBe('abc')
+  })
+
+  test('get array entry', () => {
+    const a = JSONTypes.get<string>(['abc'], 0)
+    isType<string | undefined>(a)
+    expect(a).toBe('abc')
+  })
+  test('nested', () => {
+    const a = JSONTypes.get<string>({ a: { b: [{ c: 'abc' }] } }, 'a', 'b', 0, 'c')
+    isType<string | undefined>(a)
+    expect(a).toBe('abc')
+  })
 })

--- a/src/JSONTypes.ts
+++ b/src/JSONTypes.ts
@@ -1,3 +1,17 @@
 
-export type JSONTypes = boolean | number | string | null
-  | { [key: string]: JSONTypes } | Array<JSONTypes>
+export type JSONTypes = JSONPrimitive | JSONObject | JSONArray
+
+export type JSONPrimitive = boolean | number | string | null
+
+export type JSONObject = { [key in string]?: JSONTypes }
+
+export type JSONArray = Array<JSONTypes>
+
+export const JSONTypes = { get }
+
+function get<T extends JSONTypes>(obj: JSONTypes, ...props: Array<string | number>): T | undefined {
+  if (props.length === 0) return obj as T
+  if (typeof obj !== 'object' || obj === null) return undefined
+  const p = props.shift()!
+  return get((obj as any)[p], ...props) as T
+}


### PR DESCRIPTION
When `type-plus` is used as a util library,
it is not necessary to have typescript installed.

When the consuming library is used by other library,
the problem cascade.