### PR TITLE
feat: add `as()` and `asAny()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ JSONTypes.get<string>(someJson, 'a', 'b', 1, 'c') // miku
 
 - `ANotB<A, B>`: get object with properties in `A` and not in `B`, including properties with different value type.
 - `BNotA<A, B>`: flip of `ANotB`
+- `as<T>(subject)`: assert `subject` as `T`. Avoid ASI issue such as `;(x as any).abc`
+- `asAny(subject)`: assert `subject` as `any`. Avoid ASI issue such as `;(x as any).abc`
 - `Except<T, K>`: Deprecated. Same as `Omit<T, K>`.
 - `ExcludePropType<T, U>`: excludes type `U` from properties in `T`.
 - `KeyofOptional<T>`: `keyof` that works with `Record<any, any> | undefined`.

--- a/src/utils/as.spec.ts
+++ b/src/utils/as.spec.ts
@@ -1,0 +1,24 @@
+import { as, asAny, isType } from '..'
+
+describe('as<T>()', () => {
+  test('defaults subject type to unknown', () => {
+    const s: any = {}
+    if (as(s)) isType.equal<true, unknown, typeof s>()
+  })
+
+  test('cast type to T', () => {
+    const s: any = {}
+    if (as<number>(s)) isType.equal<true, number, typeof s>()
+    if (as<string>(s)) isType.equal<true, string, typeof s>()
+    if (as<{ a: number }>(s)) isType.equal<true, { a: number }, typeof s>()
+    if (as<any>(s)) isType.equal<true, any, typeof s>()
+  })
+})
+
+describe('asAny()', () => {
+  test('cast type to any', () => {
+    const s: unknown = {}
+    if (asAny(s)) isType.equal<true, any, typeof s>()
+  })
+})
+

--- a/src/utils/as.ts
+++ b/src/utils/as.ts
@@ -1,0 +1,7 @@
+export function as<T>(subject: unknown): subject is T {
+  return true
+}
+
+export function asAny(subject: unknown): subject is any {
+  return true
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './as'
 export * from './Widen'


### PR DESCRIPTION
This is added so that we don't have to do the "workaround" for ASI:

```ts
const x = y;
(a as any).abc

// or
const x =y
;(a as any).abc
```