### PR TITLE
fix: remove type checks

### DIFF
--- a/.markdownlistignore
+++ b/.markdownlistignore
@@ -1,0 +1,2 @@
+flow-types.md
+LICENSE

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Provides additional types and type adjusted utilities for [TypeScript](https://w
 
 ## Feature Highlights
 
-- [Runtime type checker](#runtime-type-checker)
 - [Type assertion](#type-assertion)
 - [Nominal Types](#nominal-type)
 - [Type Utilities](#type-utilities)
@@ -27,59 +26,6 @@ npm install type-plus
 // or
 yarn add type-plus
 ```
-
-## Runtime type checker
-
-Bringing the power of TypeScript to JavaScript runtime.
-At the moment, this provides some basic functionalities.
-If you need more features, I would recommend other excellent type checking libraries such as [zod](https://github.com/colinhacks/zod).
-
-```ts
-const eslintConfig = T.object.create({
-  env: O.object.create({
-    es6: O.boolean
-  }),
-  parseOptions: O.object.create({
-    ecmaVersion: O.number.list(3, 5, 6, 7, 8, 9, 10, 11, 12),
-    sourceType: O.string.list('script', 'module'),
-    ecmaFeatures: O.object.create({
-      globalReturn: O.boolean,
-      impliedStrict: O.boolean,
-      jsx: O.boolean
-    })
-  }),
-  ...
-})
-
-const config: unknown = require('.eslintrc.json')
-if (T.satisfy(eslintConfig, config)) {
-  // `config` is typed here
-  config.parseOptions?.ecmaVersion // 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
-}
-else {
-  console.error(T.satisfy.getReport())
-}
-
-```
-
-All type checker functionalities are exposed as `types` (alias to `T`).
-In addition, `O` and `R` are exposed to make it easier to access optional types and required types respectively.
-
-Types supported: `any`, `array`, `boolean`, `null`, `number`, `object`, `record`, `string`, `symbol`, `tuple`, `undefined`, `union`, `unknown`.
-
-i.e., most of the basic types are supported except `bigint`.
-It is left out for backward compatibility reasons.
-
-You can use one of the three functions to perform type-check:
-
-`satisfy(type, subject)`:
-A loose type check that permits extra elements in `Tuple` and properties in `Object`.
-
-`conform(type, subject)`:
-A strict type check that does not allow extra elements in `Tuple` and properties in `Object`.
-
-`check(options, type, subject)`:
-A general form of `satisfy()` and `conform()`.
 
 ## Type Assertion
 
@@ -120,7 +66,7 @@ a standard `TypeError` will be thrown and provide better error info.
 For example:
 
 ```ts
-const s: any = 1
+const s: unknown = 1
 
 // TypeError: subject fails to satisfy s => typeof s === 'boolean'
 assertType<boolean>(s, s => typeof s === 'boolean')

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,8 @@ module.exports = {
   'collectCoverageFrom': [
     '<rootDir>/ts/**/*.[jt]s',
     '!<rootDir>/ts/bin.[jt]s',
-    '!<rootDir>/ts/type-checker/*'
+    '!<rootDir>/ts/type-checker/*',
+    '!<rootDir>/ts/types/*'
   ],
   'reporters': [
     'default',

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -1,4 +1,4 @@
-import * as types from './types'
+// import * as types from './types'
 export { required, requiredDeep } from 'unpartial'
 export * from './array'
 export * from './assertion'
@@ -14,8 +14,8 @@ export * from './object'
 export * from './predicates'
 export * from './PrimitiveTypes'
 export * from './promise'
-export * from './types/optional'
-export * from './types/required'
+// export * from './types/optional'
+// export * from './types/required'
 export * from './UnionKeys'
 export * from './utils'
-export { types, types as T }
+// export { types, types as T }

--- a/ts/type-checker/typeChecker.spec.ts
+++ b/ts/type-checker/typeChecker.spec.ts
@@ -1,4 +1,5 @@
-import { assertType, T } from '..'
+import { assertType } from '..'
+import * as T from '../types'
 import { createTypeChecker } from './typeChecker'
 
 describe('check()', () => {

--- a/ts/types/check.spec.ts
+++ b/ts/types/check.spec.ts
@@ -1,4 +1,4 @@
-import { T } from '..'
+import * as T from '.'
 import { check } from './check'
 
 test('check without strict', () => {

--- a/ts/types/conform.spec.ts
+++ b/ts/types/conform.spec.ts
@@ -1,4 +1,4 @@
-import { T } from '..'
+import * as T from '.'
 import { conform } from './conform'
 
 test('conform is strict', () => {

--- a/ts/types/satisfy.accept.ts
+++ b/ts/types/satisfy.accept.ts
@@ -1,7 +1,8 @@
 import { baseline } from '@unional/fixture'
 import fs from 'fs'
 import path from 'path'
-import { T, O } from '..'
+import * as T from '.'
+import { O } from './optional'
 
 const eslint = T.object.create({
   env: O.object.create({

--- a/ts/types/satisfy.spec.ts
+++ b/ts/types/satisfy.spec.ts
@@ -1,5 +1,6 @@
 import { satisfies } from 'satisfier'
-import { assertType, T, Equal } from '..'
+import { assertType, Equal } from '..'
+import * as T from '.'
 
 describe('undefined', () => {
   test('satisfies only undefined', () => {


### PR DESCRIPTION
Due to the infer type circular reference issue,
consumer of `type-plus` needs to turn on `skipLibCheck` in order to use `type-plus`.

It it not a good practice.
Since the type checker needs some more work,
remove it from the package to improve DX.

BREAKING CHANGE the type checker is removed from the package