### PR TITLE
chore: ignore docs folder by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ node_modules
 # project folders
 cjs
 dist*
+docs
 esm
 lib*
 out*


### PR DESCRIPTION
This prevent the folder to be accidentially added to the repo