### PR TITLE
fix: handling of multi-digit numbers in GreaterThan

### DIFF
--- a/ts/math/GreaterThan.spec.ts
+++ b/ts/math/GreaterThan.spec.ts
@@ -26,10 +26,12 @@ test('with same number of digits', () => {
   isType.t<GreaterThan<1, 0>>()
   isType.t<GreaterThan<22, 11>>()
   isType.t<GreaterThan<20, 19>>()
+  isType.t<GreaterThan<19, 10>>()
 
   isType.f<GreaterThan<0, 1>>()
   isType.f<GreaterThan<11, 22>>()
   isType.f<GreaterThan<19, 20>>()
+  isType.f<GreaterThan<10, 19>>()
 })
 
 test('with different number of digits', () => {
@@ -37,4 +39,5 @@ test('with different number of digits', () => {
   isType.f<GreaterThan<9, 100>>()
   isType.t<GreaterThan<10, 1>>()
   isType.t<GreaterThan<123, 32>>()
+  isType.t<GreaterThan<123, 13>>()
 })

--- a/ts/math/GreaterThan.ts
+++ b/ts/math/GreaterThan.ts
@@ -31,8 +31,8 @@ export namespace GreaterThan {
   )
 
   export type OnDigitArray<DA extends number[], DB extends number[]> = (
-    Equal<Head<DA>, Head<DB>> extends true ?
-    OnDigitArray<Tail<DA>, Tail<DB>> extends Tail<DA> ? true : false :
-    Digit.GreaterThan<Head<DA>, Head<DB>> extends true ? true : false
+    Equal<Head<DA>, Head<DB>> extends true
+    ? OnDigitArray<Tail<DA>, Tail<DB>>
+    : Digit.GreaterThan<Head<DA>, Head<DB>>
   )
 }


### PR DESCRIPTION
Previously, there was a mistake in the implementation which caused all digits after the first to be compared incorrectly.

There seems to be an issue with the line endings in `GreaterThan.spec.ts`, not sure if this is an issue on my end (Windows) but you might want to add a `.gitattributes` file so that it can be managed automatically.

I also couldn't get linting or husky to work on my machine; I think you have some of the dependencies installed globally rather than in package.json, which could be part of the problem.

Closes #161.