### PR TITLE
chore: fix gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-core.eol=LF
-core.autocrlf=false
+* text=auto eol=lf


### PR DESCRIPTION
Should set core.autocrlf=true and eol=lf

because core.autocrlf=false only works if you and your team has the environment setup as LF already.

If contributor do not have it setup, e.g. VSCode with no line ending,

the file will be in CRLF.