### PR TITLE
fix: Equal<A,B> with union types

### DIFF
--- a/ts/array/Concat.spec.ts
+++ b/ts/array/Concat.spec.ts
@@ -12,7 +12,7 @@ test('concat tuples', () => {
 
 test('concat array to tuple', () => {
   type A = Concat<string[], [1, 2, 3]>
-  isType.t<Equal<Array<string | 1 | 2 | 3>, A>>()
+  isType.t<Equal<[...string[], 1, 2, 3], A>>()
 })
 
 test('concat tuple to array', () => {

--- a/ts/object/ValueOf.ts
+++ b/ts/object/ValueOf.ts
@@ -1,1 +1,2 @@
+
 export type ValueOf<T> = T[keyof T]

--- a/ts/predicates/Equal.spec.ts
+++ b/ts/predicates/Equal.spec.ts
@@ -1,6 +1,6 @@
 import { assertType, Equal, NotEqual } from '../index.js'
 
-describe('TypeEquals', () => {
+describe('Equal<A, B>', () => {
   test('match', () => {
     assertType.isTrue(true as Equal<false, false>)
   })
@@ -54,9 +54,14 @@ describe('TypeEquals', () => {
   test('overlap is false', () => {
     assertType.isFalse(false as Equal<{ a: 1, b: 1 }, { a: 1, c: 2 }>)
   })
+
+  it('works with union types', () => {
+    assertType.isTrue(true as Equal<{ a: number, b: string }, { a: number } & { b: string }>)
+    assertType.isTrue(true as Equal<{ a: number, b?: string }, { a: number } & { b?: string }>)
+  })
 })
 
-describe('TypeNotEquals', () => {
+describe('NotEqual<A, B>', () => {
   test('boolean', () => {
     assertType.isFalse(false as NotEqual<boolean, boolean>)
     assertType.isFalse(false as NotEqual<true, true>)
@@ -67,5 +72,9 @@ describe('TypeNotEquals', () => {
     assertType.isTrue(true as NotEqual<false, boolean>)
     assertType.isTrue(true as NotEqual<false, true>)
     assertType.isTrue(true as NotEqual<true, false>)
+  })
+  it('works with union types', () => {
+    assertType.isFalse(false as NotEqual<{ a: number, b: string }, { a: number } & { b: string }>)
+    assertType.isTrue(true as NotEqual<{ a: number, b: string }, { a: number } & { b?: string }>)
   })
 })

--- a/ts/predicates/Equal.spec.ts
+++ b/ts/predicates/Equal.spec.ts
@@ -1,4 +1,4 @@
-import { assertType, Equal, NotEqual } from '../index.js'
+import { assertType, Equal, NotEqual, ValueOf } from '../index.js'
 
 describe('Equal<A, B>', () => {
   test('match', () => {
@@ -59,6 +59,12 @@ describe('Equal<A, B>', () => {
     assertType.isTrue(true as Equal<{ a: number, b: string }, { a: number } & { b: string }>)
     assertType.isTrue(true as Equal<{ a: number, b?: string }, { a: number } & { b?: string }>)
   })
+
+  it('works with never type', () => {
+    assertType.isTrue(true as Equal<never, never>)
+    assertType.isFalse(false as Equal<never, 1>)
+    assertType.isFalse(false as Equal<1, never>)
+  })
 })
 
 describe('NotEqual<A, B>', () => {
@@ -76,5 +82,10 @@ describe('NotEqual<A, B>', () => {
   it('works with union types', () => {
     assertType.isFalse(false as NotEqual<{ a: number, b: string }, { a: number } & { b: string }>)
     assertType.isTrue(true as NotEqual<{ a: number, b: string }, { a: number } & { b?: string }>)
+  })
+  it('works with never type', () => {
+    assertType.isFalse(false as NotEqual<never, never>)
+    assertType.isTrue(true as NotEqual<never, 1>)
+    assertType.isFalse(false as Equal<never, NotEqual<never, ValueOf<string>>>)
   })
 })

--- a/ts/predicates/Equal.ts
+++ b/ts/predicates/Equal.ts
@@ -11,13 +11,17 @@
  * Checks if two types are equal.
  */
 export type Equal<A, B, Then = true, Else = false> =
-  [A, B] extends [object, object]
-  ? (A extends B ? B extends A ? Then : Else : Else)
-  : (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? Then : Else
+  [A, B] extends [boolean | string | number, boolean | string | number]
+  ? (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? Then : Else
+  : ([A] extends [never]
+    ? ([B] extends [never] ? Then : Else)
+    : (A extends B ? B extends A ? Then : Else : Else))
 export type IsEqual<A, B> = Equal<A, B>
 
 export type NotEqual<A, B, Then = true, Else = false> =
-  [A, B] extends [object, object]
-  ? (A extends B ? B extends A ? Else : Then : Then)
-  : (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? Else : Then
+  [A, B] extends [boolean | string | number, boolean | string | number]
+  ? (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? Else : Then
+  : ([A] extends [never]
+    ? ([B] extends [never] ? Then : Else)
+    : (A extends B ? B extends A ? Else : Then : Then))
 export type IsNotEqual<A, B> = NotEqual<A, B>

--- a/ts/predicates/Equal.ts
+++ b/ts/predicates/Equal.ts
@@ -1,14 +1,23 @@
 /**
+ * `<T>() => T extends A ? 1 : 2` idea originate from `typepark`
+ * But it does not work with union types.
+ *
+ * `<T>() => T extends A` is a trick to create an inferred type `T`.
+ * This is needed for `boolean`, `string`, and `number`,
+ * as they supports literal types.
+ */
+
+/**
  * Checks if two types are equal.
- * Borrow from `typepark`.
- * The simple `A extends B ? B extends A ? true : false : false`
- * does not work with boolean type.
  */
 export type Equal<A, B, Then = true, Else = false> =
-  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
-  ? Then : Else
+  [A, B] extends [object, object]
+  ? (A extends B ? B extends A ? Then : Else : Else)
+  : (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? Then : Else
 export type IsEqual<A, B> = Equal<A, B>
 
 export type NotEqual<A, B, Then = true, Else = false> =
-  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? Else : Then
+  [A, B] extends [object, object]
+  ? (A extends B ? B extends A ? Else : Then : Then)
+  : (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? Else : Then
 export type IsNotEqual<A, B> = NotEqual<A, B>


### PR DESCRIPTION
The original implementation from `tyeppark` does not work with union type.