### PR TITLE
Work around excessive stack depth error in TS 5.4

### DIFF
--- a/.changeset/late-seals-lick.md
+++ b/.changeset/late-seals-lick.md
@@ -1,0 +1,5 @@
+---
+"type-plus": patch
+---
+
+Work around excessive stack depth error in TS 5.4 for type `Zeros`.

--- a/packages/type-plus/src/math/numeric_struct.ts
+++ b/packages/type-plus/src/math/numeric_struct.ts
@@ -433,7 +433,7 @@ export namespace DigitArray {
 		? Multiply<A, Tail, [...R, CarryDigits<MultiplyArray<A, Head, Zeros<Tail['length']>>>]>
 		: never
 
-	type Zeros<N extends number, R extends number[] = []> = R['length'] extends N ? R : Zeros<N, [0, ...R]>
+	type Zeros<N extends number, R extends number[] = []> = N extends unknown ? R['length'] extends N ? R : Zeros<N, [0, ...R]> : never
 
 	type MultiplyArray<
 		A extends number[],


### PR DESCRIPTION
After updating to TypeScript 5.4 in my project and checking with `skipLibCheck: false`, I started getting an excessive stack depth error that pointed at the `Multiply` type. After digging into it, the problem *actually* seems to come from `Zeros`.

By treating the first type parameter of `Zeros` as a distributive conditional type, we defer its evaluation enough to avoid the error.